### PR TITLE
Fix VRAM leak for Multimodal/Vision models (Capture & Kill strategy)

### DIFF
--- a/gguf_inference.py
+++ b/gguf_inference.py
@@ -293,62 +293,95 @@ class GGUFInference:
     CATEGORY = "ListHelper/LLM"
 
     def _free_memory(self):
-        """Free GPU and system memory"""
+        """Free memory with robust handling for Vision Handlers & Zombie Wrappers"""
+        print("🧹 Releasing resources...")
         try:
-            # Clear chat_handler first (it may hold references to model)
+            import llama_cpp
+            
+            # 1. Vision Cleanup (Qwen2.5-VL / Llava)
             if self.clip_model_array is not None:
-                try:
-                    # Try to explicitly close/cleanup chat_handler if it has such methods
-                    if hasattr(self.clip_model_array, 'clip_ctx') and self.clip_model_array.clip_ctx is not None:
-                        del self.clip_model_array.clip_ctx
-                    if hasattr(self.clip_model_array, '_clip_free'):
-                        try:
-                            self.clip_model_array._clip_free()
-                        except:
-                            pass
-                except:
-                    pass
+                # Capture pointer (legacy handlers)
+                clip_ptr = None
+                if hasattr(self.clip_model_array, 'clip_model'):
+                    clip_ptr = self.clip_model_array.clip_model
+                elif hasattr(self.clip_model_array, 'vision_model'):
+                    clip_ptr = self.clip_model_array.vision_model
+
+                # A. Close Exit Stack (Crucial for Qwen25VLChatHandler)
+                if hasattr(self.clip_model_array, '_exit_stack') and self.clip_model_array._exit_stack:
+                    try: self.clip_model_array._exit_stack.close()
+                    except: pass
+
+                # B. Standard Close
+                if hasattr(self.clip_model_array, 'close'):
+                    try: self.clip_model_array.close()
+                    except: pass
+                
+                # C. Force Kill (Legacy/Direct Pointer)
+                if clip_ptr:
+                     try: llama_cpp.llama_free_model(clip_ptr)
+                     except: pass
 
                 del self.clip_model_array
                 self.clip_model_array = None
 
-                # Force garbage collection after freeing chat_handler
-                gc.collect()
-
-            # Clear model
+            # 2. Main Model Cleanup
             if self.model is not None:
-                try:
-                    # Try to explicitly close model context if available
-                    if hasattr(self.model, 'close'):
-                        self.model.close()
-                    if hasattr(self.model, '_ctx') and self.model._ctx is not None:
-                        del self.model._ctx
-                except:
-                    pass
+                # --- CAPTURE RAW POINTERS ---
+                raw_model_ptr = None
+                raw_ctx_ptr = None
+                
+                if hasattr(self.model, '_model') and self.model._model:
+                    if hasattr(self.model._model, 'model'):
+                        raw_model_ptr = self.model._model.model
+                    else:
+                        raw_model_ptr = self.model._model
+                elif hasattr(self.model, 'model') and self.model.model:
+                     raw_model_ptr = self.model.model
 
+                if hasattr(self.model, '_ctx') and self.model._ctx:
+                    if hasattr(self.model._ctx, 'ctx'):
+                        raw_ctx_ptr = self.model._ctx.ctx
+                    else:
+                        raw_ctx_ptr = self.model._ctx
+                
+                # A. Try Standard Close
+                if hasattr(self.model, 'close'):
+                    try: self.model.close()
+                    except: pass
+                
+                # B. FORCE KILL using Captured Pointers
+                if raw_model_ptr:
+                    try: llama_cpp.llama_free_model(raw_model_ptr)
+                    except: pass
+
+                if raw_ctx_ptr:
+                    try: llama_cpp.llama_free(raw_ctx_ptr)
+                    except: pass
+
+                # C. Nullify Wrappers
+                if hasattr(self.model, '_model'): self.model._model = None
+                if hasattr(self.model, '_ctx'): self.model._ctx = None
+                
                 del self.model
                 self.model = None
 
             self.current_model_path = None
             self.current_mmproj_path = None
 
-            # Run garbage collection multiple times to ensure cleanup
-            for _ in range(3):
-                gc.collect()
-
-            # Try to free CUDA memory if available
+            # 3. System Cleanup
+            import gc
+            gc.collect() 
+            gc.collect() 
             try:
                 import torch
                 if torch.cuda.is_available():
                     torch.cuda.empty_cache()
-                    torch.cuda.synchronize()
-                    # Force empty cache again
-                    torch.cuda.empty_cache()
-            except:
-                pass
+                    torch.cuda.ipc_collect()
+            except: pass
 
-            # Memory freed silently
-            pass
+            print("✓ Resources released")
+
         except Exception as e:
             print(f"⚠️ Error freeing memory: {e}")
 
@@ -888,6 +921,8 @@ class GGUFInference:
                 "n_ctx": 8192,
                 "n_gpu_layers": -1,  # Use GPU if available
                 "verbose": False,
+                "use_mmap": False, # Disable mmap for clean unload
+                "use_mlock": False,
             }
 
             # Load vision model if it's a VL model and vision is enabled
@@ -1223,6 +1258,26 @@ class GGUFInference:
                     print("⚠️ GGML compatibility error detected during force reload")
                 else:
                     raise
+
+        # --- NEW: Clear KV Cache to prevent context overflow on re-runs ---
+        try:
+             import llama_cpp
+             # Attempt to find the low-level context pointer
+             ctx_ptr = getattr(self.model, 'ctx', None)
+             if not ctx_ptr and hasattr(self.model, '_ctx'):
+                 ctx_ptr = getattr(self.model._ctx, 'ctx', self.model._ctx)
+
+             if ctx_ptr:
+                 # Strategy A: Modern API (v0.3+)
+                 if hasattr(llama_cpp, 'llama_get_memory'):
+                     mem = llama_cpp.llama_get_memory(ctx_ptr)
+                     llama_cpp.llama_memory_seq_rm(mem, -1, 0, -1)
+                 # Strategy B: Legacy API
+                 elif hasattr(llama_cpp, 'llama_kv_cache_seq_rm'):
+                     llama_cpp.llama_kv_cache_seq_rm(ctx_ptr, -1, 0, -1)
+        except Exception as e:
+             print(f"Warning: Could not clear KV cache at start: {e}")
+        # ---------------------------------------------------------------
 
         # Handle ggml error with auto-reinstall
         if ggml_error_occurred and auto_install_llama_cpp:


### PR DESCRIPTION
🔍 Problem
When running large GGUF models (especially Multimodal/Vision models like Qwen2.5-VL or Llava) in ComfyUI, VRAM is not fully released after the node execution or when switching models.
- Residual VRAM: Approximately 2-4GB remains occupied per run (corresponding to the Model Weights and Vision Tower).
- Result: "CUDA Out of Memory" errors after 2-3 generations, requiring a full ComfyUI restart.

🐛 Root Cause Analysis
- "Zombie" Wrappers: The llama-cpp-python Llama.close() method sets internal Python attributes to None. If the underlying C++ release fails (or is delayed by circular references common in ComfyUI), the Python object becomes "empty" but the C-pointer remains allocated in VRAM. Since the reference is lost, it can never be freed.
- Vision Handler Exit Stacks: Modern handlers (like Qwen25VLChatHandler) use contextlib.ExitStack to manage resources (like mtmd_ctx). Standard del or garbage collection does not always trigger the exit stack closure immediately, leaving the Vision Tower in VRAM.
- Memory Mapping: Default use_mmap=True can cause the OS to hold onto file handles and memory pages even after the application thinks it has unloaded the model.

🛠️ Solution
This PR implements a robust "Capture & Kill" memory management strategy in gguf_inference.py:
- Disable Mmap: Sets use_mmap=False in _load_model to ensure deterministic unloading.
- Capture Pointers: In _free_memory, we extract the raw C-memory addresses (c_void_p) before calling .close().
- Force Free: We explicitly pass these captured pointers to llama_cpp.llama_free_model, guaranteeing the driver releases VRAM regardless of the Python object's state.
- Vision Stack Cleanup: Explicitly closes the _exit_stack for Vision Handlers to release Multimodal Contexts (mtmd_ctx).
- KV Cache Clear: Adds a routine in inference to clear the KV cache before generation, preventing context overflow errors on re-runs.

🧪 Testing
Tested with Qwen2.5-VL-7B-Instruct-abliterated.Q6_K.gguf on an RTX 4090.
- Before: VRAM grew by +2.5GB per run, eventually crashing.
- After: VRAM returns to exact baseline levels (Residual 0MB) after every run.

📝 Changes
- Modified _load_model: Added use_mmap=False.
- Modified inference: Added KV cache cleanup logic.
- Rewrote _free_memory: Implemented aggressive pointer cleanup for both Main Model and Vision Handler.